### PR TITLE
feat: Adds support for hue `temperature` and `light_level` sensors

### DIFF
--- a/src/hue/event_data.rs
+++ b/src/hue/event_data.rs
@@ -70,7 +70,7 @@ enum UpdateData {
     Light(LightUpdateData),
     Motion(MotionUpdateData),
     Temperature(TemperatureUpdateData),
-    LightLevel(LightLevelUpdateData),         // Light sensor update
+    LightLevel(LightLevelUpdateData),
 
     // Ignored updates
     DevicePower,        // Battery level update

--- a/src/hue/event_data.rs
+++ b/src/hue/event_data.rs
@@ -39,6 +39,28 @@ struct MotionUpdateData {
 }
 
 #[derive(Deserialize, Debug, Clone)]
+struct TemperatureData {
+    temperature: f64,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+struct TemperatureUpdateData {
+    id: String,
+    temperature: TemperatureData,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+struct LightLevelData {
+    light_level: f64,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+struct LightLevelUpdateData {
+    id: String,
+    light_level: LightLevelData,
+}
+
+#[derive(Deserialize, Debug, Clone)]
 struct DevicePowerData {}
 
 #[derive(Deserialize, Debug, Clone)]
@@ -47,10 +69,10 @@ enum UpdateData {
     Button(ButtonUpdateData),
     Light(LightUpdateData),
     Motion(MotionUpdateData),
+    Temperature(TemperatureUpdateData),
+    LightLevel(LightLevelUpdateData),         // Light sensor update
 
     // Ignored updates
-    Temperature,        // Temperature sensor update
-    LightLevel,         // Light sensor update
     DevicePower,        // Battery level update
     GroupedLight,       // Light groups update
     ZigbeeConnectivity, // Connectivity issue update
@@ -88,6 +110,20 @@ impl UpdateData {
                 let mut mqtt_device = mqtt_devices.get(&motion.id)?.clone();
 
                 mqtt_device.sensor_value = Some(motion.motion.motion.to_string());
+
+                return Some(mqtt_device);
+            }
+            UpdateData::Temperature(temperature) => {
+                let mut mqtt_device = mqtt_devices.get(&temperature.id)?.clone();
+
+                mqtt_device.sensor_value = Some(temperature.temperature.temperature.to_string());
+
+                return Some(mqtt_device);
+            }
+            UpdateData::LightLevel(light_level) => {
+                let mut mqtt_device = mqtt_devices.get(&light_level.id)?.clone();
+
+                mqtt_device.sensor_value = Some(light_level.light_level.light_level.to_string());
 
                 return Some(mqtt_device);
             }
@@ -204,6 +240,8 @@ pub async fn handle_incoming_hue_events(
                     .filter(|data| {
                         (matches!(data, UpdateData::Button(_)) && !ignore_buttons)
                             | matches!(data, UpdateData::Motion(_))
+                            | matches!(data, UpdateData::Temperature(_))
+                            | matches!(data, UpdateData::LightLevel(_))
                     })
                     .filter(|data| match data {
                         UpdateData::Button(button) => {

--- a/src/hue/event_data.rs
+++ b/src/hue/event_data.rs
@@ -57,7 +57,7 @@ struct LightLevelData {
 #[derive(Deserialize, Debug, Clone)]
 struct LightLevelUpdateData {
     id: String,
-    light_level: LightLevelData,
+    light: LightLevelData,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -123,7 +123,7 @@ impl UpdateData {
             UpdateData::LightLevel(light_level) => {
                 let mut mqtt_device = mqtt_devices.get(&light_level.id)?.clone();
 
-                mqtt_device.sensor_value = Some(light_level.light_level.light_level.to_string());
+                mqtt_device.sensor_value = Some(light_level.light.light_level.to_string());
 
                 return Some(mqtt_device);
             }

--- a/src/hue/init_state.rs
+++ b/src/hue/init_state.rs
@@ -111,6 +111,46 @@ pub fn init_state_to_mqtt_devices(init_state: &HueState) -> HashMap<String, Mqtt
         }
     }
 
+    for temperature in init_state.temperature.values() {
+        let device = init_state.devices.get(&temperature.owner.rid);
+
+        if let Some(device) = device {
+            let mut builder = MqttDeviceBuilder::default();
+
+            builder
+                .id(temperature.id.clone())
+                .name(format!("{} {}", device.metadata.name.clone(), " temperature".to_string()));
+
+            if let Some(temperature_event) = &temperature.temperature {
+                builder.sensor_value(temperature_event.temperature.to_string());
+            }
+
+            let mqtt_device = builder.build().unwrap();
+
+            mqtt_devices.insert(mqtt_device.id.clone(), mqtt_device);
+        }
+    }
+
+    for light_level in init_state.light_level.values() {
+        let device = init_state.devices.get(&light_level.owner.rid);
+
+        if let Some(device) = device {
+            let mut builder = MqttDeviceBuilder::default();
+
+            builder
+                .id(light_level.id.clone())
+                .name(format!("{} {}", device.metadata.name.clone(), " light level".to_string()));
+
+            if let Some(light_level_event) = &light_level.light_level {
+                builder.sensor_value(light_level_event.light_level.to_string());
+            }
+
+            let mqtt_device = builder.build().unwrap();
+
+            mqtt_devices.insert(mqtt_device.id.clone(), mqtt_device);
+        }
+    }
+
     mqtt_devices
 }
 

--- a/src/hue/init_state.rs
+++ b/src/hue/init_state.rs
@@ -117,9 +117,11 @@ pub fn init_state_to_mqtt_devices(init_state: &HueState) -> HashMap<String, Mqtt
         if let Some(device) = device {
             let mut builder = MqttDeviceBuilder::default();
 
-            builder
-                .id(temperature.id.clone())
-                .name(format!("{} {}", device.metadata.name.clone(), " temperature".to_string()));
+            builder.id(temperature.id.clone()).name(format!(
+                "{} {}",
+                device.metadata.name.clone(),
+                " temperature"
+            ));
 
             if let Some(temperature_event) = &temperature.temperature {
                 builder.sensor_value(temperature_event.temperature.to_string());
@@ -137,9 +139,11 @@ pub fn init_state_to_mqtt_devices(init_state: &HueState) -> HashMap<String, Mqtt
         if let Some(device) = device {
             let mut builder = MqttDeviceBuilder::default();
 
-            builder
-                .id(light_level.id.clone())
-                .name(format!("{} {}", device.metadata.name.clone(), " light level".to_string()));
+            builder.id(light_level.id.clone()).name(format!(
+                "{} {}",
+                device.metadata.name.clone(),
+                " light level"
+            ));
 
             if let Some(light_level_event) = &light_level.light_level {
                 builder.sensor_value(light_level_event.light_level.to_string());

--- a/src/hue/init_state.rs
+++ b/src/hue/init_state.rs
@@ -120,7 +120,7 @@ pub fn init_state_to_mqtt_devices(init_state: &HueState) -> HashMap<String, Mqtt
             builder.id(temperature.id.clone()).name(format!(
                 "{} {}",
                 device.metadata.name.clone(),
-                " temperature"
+                "temperature"
             ));
 
             if let Some(temperature_event) = &temperature.temperature {
@@ -142,10 +142,10 @@ pub fn init_state_to_mqtt_devices(init_state: &HueState) -> HashMap<String, Mqtt
             builder.id(light_level.id.clone()).name(format!(
                 "{} {}",
                 device.metadata.name.clone(),
-                " light level"
+                "light level"
             ));
 
-            if let Some(light_level_event) = &light_level.light_level {
+            if let Some(light_level_event) = &light_level.light {
                 builder.sensor_value(light_level_event.light_level.to_string());
             }
 

--- a/src/hue/rest/light_level.rs
+++ b/src/hue/rest/light_level.rs
@@ -19,7 +19,7 @@ pub struct LightLevelData {
     pub id_v1: String,
     pub owner: Owner,
     pub enabled: bool,
-    pub light_level: Option<LightLevelEventData>,
+    pub light: Option<LightLevelEventData>,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/src/hue/rest/light_level.rs
+++ b/src/hue/rest/light_level.rs
@@ -1,0 +1,43 @@
+use color_eyre::Result;
+use serde::Deserialize;
+
+use crate::{
+    protocols::https::{mk_get_request, HyperHttpsClient},
+    settings::Settings,
+};
+
+use super::common::Owner;
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct LightLevelEventData {
+    pub light_level: i64,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct LightLevelData {
+    pub id: String,
+    pub id_v1: String,
+    pub owner: Owner,
+    pub enabled: bool,
+    pub light_level: Option<LightLevelEventData>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+struct LightLevelResponse {
+    data: Vec<LightLevelData>,
+}
+
+pub async fn get_hue_light_level(
+    settings: &Settings,
+    client: &HyperHttpsClient,
+) -> Result<Vec<LightLevelData>> {
+    let uri = format!(
+        "https://{}/clip/v2/resource/light_level",
+        settings.hue_bridge.addr
+    )
+    .parse()?;
+
+    let response: LightLevelResponse = mk_get_request(client, settings, &uri).await?;
+
+    Ok(response.data)
+}

--- a/src/hue/rest/mod.rs
+++ b/src/hue/rest/mod.rs
@@ -5,6 +5,8 @@ use self::{
     device::{get_hue_devices, DeviceData},
     light::{get_hue_lights, LightData},
     motion::{get_hue_motion, MotionData},
+    temperature::{get_hue_temperature, TemperatureData},
+    light_level::{get_hue_light_level, LightLevelData},
 };
 use crate::{protocols::https::HyperHttpsClient, settings::Settings};
 use color_eyre::Result;
@@ -14,6 +16,8 @@ pub mod common;
 pub mod device;
 pub mod light;
 pub mod motion;
+pub mod temperature;
+pub mod light_level;
 
 #[derive(Clone, Debug)]
 pub struct HueState {
@@ -21,6 +25,8 @@ pub struct HueState {
     pub buttons: HashMap<String, ButtonData>,
     pub lights: HashMap<String, LightData>,
     pub motion: HashMap<String, MotionData>,
+    pub temperature: HashMap<String, TemperatureData>,
+    pub light_level: HashMap<String, LightLevelData>,
 }
 
 pub async fn get_hue_state(settings: &Settings, client: &HyperHttpsClient) -> Result<HueState> {
@@ -28,6 +34,8 @@ pub async fn get_hue_state(settings: &Settings, client: &HyperHttpsClient) -> Re
     let buttons = get_hue_buttons(settings, client).await?;
     let lights = get_hue_lights(settings, client).await?;
     let motion = get_hue_motion(settings, client).await?;
+    let temperature = get_hue_temperature(settings, client).await?;
+    let light_level = get_hue_light_level(settings, client).await?;
 
     // Fix some data quality issues
     let buttons: Vec<ButtonData> = buttons
@@ -58,11 +66,15 @@ pub async fn get_hue_state(settings: &Settings, client: &HyperHttpsClient) -> Re
     let buttons = buttons.into_iter().map(|x| (x.id.clone(), x)).collect();
     let lights = lights.into_iter().map(|x| (x.id.clone(), x)).collect();
     let motion = motion.into_iter().map(|x| (x.id.clone(), x)).collect();
+    let temperature = temperature.into_iter().map(|x| (x.id.clone(), x)).collect();
+    let light_level = light_level.into_iter().map(|x| (x.id.clone(), x)).collect();
 
     Ok(HueState {
         devices,
         buttons,
         lights,
         motion,
+        temperature,
+        light_level,
     })
 }

--- a/src/hue/rest/mod.rs
+++ b/src/hue/rest/mod.rs
@@ -4,9 +4,9 @@ use self::{
     button::{get_hue_buttons, ButtonData, ButtonEventData, ButtonReport},
     device::{get_hue_devices, DeviceData},
     light::{get_hue_lights, LightData},
+    light_level::{get_hue_light_level, LightLevelData},
     motion::{get_hue_motion, MotionData},
     temperature::{get_hue_temperature, TemperatureData},
-    light_level::{get_hue_light_level, LightLevelData},
 };
 use crate::{protocols::https::HyperHttpsClient, settings::Settings};
 use color_eyre::Result;
@@ -15,9 +15,9 @@ pub mod button;
 pub mod common;
 pub mod device;
 pub mod light;
+pub mod light_level;
 pub mod motion;
 pub mod temperature;
-pub mod light_level;
 
 #[derive(Clone, Debug)]
 pub struct HueState {

--- a/src/hue/rest/temperature.rs
+++ b/src/hue/rest/temperature.rs
@@ -1,0 +1,43 @@
+use color_eyre::Result;
+use serde::Deserialize;
+
+use crate::{
+    protocols::https::{mk_get_request, HyperHttpsClient},
+    settings::Settings,
+};
+
+use super::common::Owner;
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct TemperatureEventData {
+    pub temperature: f64,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct TemperatureData {
+    pub id: String,
+    pub id_v1: String,
+    pub owner: Owner,
+    pub enabled: bool,
+    pub temperature: Option<TemperatureEventData>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+struct TemperatureResponse {
+    data: Vec<TemperatureData>,
+}
+
+pub async fn get_hue_temperature(
+    settings: &Settings,
+    client: &HyperHttpsClient,
+) -> Result<Vec<TemperatureData>> {
+    let uri = format!(
+        "https://{}/clip/v2/resource/temperature",
+        settings.hue_bridge.addr
+    )
+    .parse()?;
+
+    let response: TemperatureResponse = mk_get_request(client, settings, &uri).await?;
+
+    Ok(response.data)
+}


### PR DESCRIPTION
TODO: fix light_level not working

I'm not sure what happens during the deserialisation, but `light_level` doesn't get parsed into the result. The JSON result looks like below when checking through the CLIP API Debugger:

``` json
{
	"id": "long-id",
	"id_v1": "/sensors/50",
	"owner": {
		"rid": "long-id",
		"rtype": "device"
	},
	"enabled": true,
	"light": {
		"light_level": 11179,
		"light_level_valid": true,
		"light_level_report": {
			"changed": "2023-07-31T11:16:06.581Z",
			"light_level": 11179
		}
	},
	"type": "light_level"
		}
```

I suppose the `"light": { "light_level" : value, ... }` is the problem because `_level` is missing from the root `light` entry.